### PR TITLE
add hitmap manipulation

### DIFF
--- a/src/StringUtils.sol
+++ b/src/StringUtils.sol
@@ -90,7 +90,11 @@ library StringUtils {
     }
 
     // function that updates the hitmap state for a given index
-    function updateHitmap(CharState[] memory hitmap, uint256 index, uint256 state) internal pure returns (CharState[] memory) {
+    function updateHitmap(CharState[] memory hitmap, uint256 index, uint256 state)
+        internal
+        pure
+        returns (CharState[] memory)
+    {
         if (index >= hitmap.length) {
             revert("Index out of bounds");
         }
@@ -99,7 +103,7 @@ library StringUtils {
         }
         if (hitmap[index].state < 2) {
             hitmap[index].state = state;
-        } 
+        }
     }
 
     // function that checks if the hitmap is complete

--- a/src/StringUtils.sol
+++ b/src/StringUtils.sol
@@ -78,6 +78,8 @@ library StringUtils {
         return false;
     }
 
+    // function that generates the hitmap for the target string and controls
+    // correct / wrong state;
     function generateHitmap(string memory target) internal pure returns (CharState[] memory) {
         bytes memory bStr = bytes(toLowerCase(target));
         CharState[] memory res = new CharState[](bStr.length);
@@ -85,5 +87,28 @@ library StringUtils {
             res[i] = CharState({char: string(abi.encodePacked((bStr[i]))), state: 0});
         }
         return res;
+    }
+
+    // function that updates the hitmap state for a given index
+    function updateHitmap(CharState[] memory hitmap, uint256 index, uint256 state) internal pure returns (CharState[] memory) {
+        if (index >= hitmap.length) {
+            revert("Index out of bounds");
+        }
+        if (state > 2) {
+            revert("Invalid state.");
+        }
+        if (hitmap[index].state < 2) {
+            hitmap[index].state = state;
+        } 
+    }
+
+    // function that checks if the hitmap is complete
+    function isHitmapComplete(CharState[] memory hitmap) internal pure returns (bool) {
+        for (uint256 i = 0; i < hitmap.length; i++) {
+            if (hitmap[i].state == 0) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/test/StringUtils.t.sol
+++ b/test/StringUtils.t.sol
@@ -84,7 +84,7 @@ contract TestStringMethods is Test {
     }
 
     // test hitmap completion checker
-    function test_completeHitmap() public pure {
+    function test_isHitmapComplete() public pure {
         StringUtils.CharState[] memory hitmap = StringUtils.generateHitmap("HI");
         assertFalse(StringUtils.isHitmapComplete(hitmap));
 

--- a/test/StringUtils.t.sol
+++ b/test/StringUtils.t.sol
@@ -3,11 +3,11 @@ pragma solidity ^0.8.28;
 import {Test} from "forge-std/Test.sol";
 import {StringUtils} from "../src/StringUtils.sol";
 
-contract WordleTest is Test {
+contract TestStringMethods is Test {
     using StringUtils for string;
 
     // test ascii/non-ascii checker
-    function test_isASCII() public {
+    function test_isASCII() public pure {
         // non-ascii words
         string memory asciiString = "Hello, world";
         string memory nonAsciiString = unicode"👋👋";
@@ -16,19 +16,19 @@ contract WordleTest is Test {
     }
 
     // test string method to convert string to lower case
-    function test_toLowerCase() public {
+    function test_toLowerCase() public pure {
         string memory fullCaps = "HELLO";
         assertEq(fullCaps.toLowerCase(), "hello");
 
         string memory someCaps = "HeLLo";
-        assertEq(fullCaps.toLowerCase(), "hello");
+        assertEq(someCaps.toLowerCase(), "hello");
 
         string memory upperAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
         assertEq(upperAlphabet.toLowerCase(), "abcdefghijklmnopqrstuvwxyz");
     }
 
     // test string comparator
-    function test_compareStrings() public {
+    function test_compareStrings() public pure {
         // accept non-ascii for the timebeing
         assertTrue(StringUtils.areEqual(unicode"👋", unicode"👋"));
         assertTrue(StringUtils.areEqual("HELLO", "hello"));
@@ -51,7 +51,7 @@ contract WordleTest is Test {
     }
 
     // test generate hitmap function
-    function test_generateHitmap() public {
+    function test_generateHitmap() public pure {
         StringUtils.CharState[] memory hitmap = StringUtils.generateHitmap("HI");
 
         // test length
@@ -63,5 +63,34 @@ contract WordleTest is Test {
 
         assertEq(hitmap[1].char, "i");
         assertEq(hitmap[1].state, 0);
+    }
+
+    // test update hitmap function
+    function test_updateHitmap() public {
+        StringUtils.CharState[] memory hitmap = StringUtils.generateHitmap("HI");
+        StringUtils.updateHitmap(hitmap, 0, 1);
+        assertEq(hitmap[0].state, 1);
+
+        StringUtils.updateHitmap(hitmap, 1, 2);
+        assertEq(hitmap[1].state, 2);
+
+        // test out maxed state
+        vm.expectRevert("Invalid state.");
+        StringUtils.updateHitmap(hitmap, 0, 3);
+
+        // test index out ouf bounds
+        vm.expectRevert("Index out of bounds");
+        StringUtils.updateHitmap(hitmap, 3, 2);
+    }
+
+    // test hitmap completion checker
+    function test_completeHitmap() public pure {
+        StringUtils.CharState[] memory hitmap = StringUtils.generateHitmap("HI");
+        assertFalse(StringUtils.isHitmapComplete(hitmap));
+
+        // test for completion
+        StringUtils.updateHitmap(hitmap, 0, 2);
+        StringUtils.updateHitmap(hitmap, 1, 2);
+        assertTrue(StringUtils.isHitmapComplete(hitmap));
     }
 }


### PR DESCRIPTION
## Why:
To check if player guess is right or wrong the hitmap must be
manipulated and updated on each try.

## How:
By introducing two new methods for hitmap manipulation.

- `updateHitmap`, which updates the state of a given index to the
pre-determined state;

- `isHitmapComplete`, which checks if the hitmap is complete (wining
condition);

Also adds test cases for the added functions and minor changes /
renamings.