### PR TITLE
add mapings and interfaces

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -11,12 +11,15 @@ contract WordleFactory is Script {
         vm.startBroadcast(deployerPrivateKey);
 
         // Deploy the token
-        WDLToken token = new WDLToken(1000);
+        WDLToken token = new WDLToken(10000);
         address tokenAddress = address(token);
 
         // Deploy Wordle
         string memory word = vm.envString("HIDDEN_WORD");
         Wordle wordle = new Wordle(word, tokenAddress);
+
+        // Create a token pool to be issued as rewards / faucet
+        token.transfer(address(wordle), 1000 * 10 ** 18);
 
         vm.stopBroadcast();
     }

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -3,14 +3,20 @@ pragma solidity ^0.8.28;
 
 import "forge-std/Script.sol";
 import {WDLToken} from "../src/ERC20.sol";
+import {Wordle} from "../src/Wordle.sol";
 
-contract ERC20Script is Script {
+contract WordleFactory is Script {
     function run() external {
         uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
         vm.startBroadcast(deployerPrivateKey);
 
         // Deploy the token
         WDLToken token = new WDLToken(1000);
+        address tokenAddress = address(token);
+
+        // Deploy Wordle
+        string memory word = vm.envString("HIDDEN_WORD");
+        Wordle wordle = new Wordle(word, tokenAddress);
 
         vm.stopBroadcast();
     }

--- a/src/ERC20.sol
+++ b/src/ERC20.sol
@@ -5,6 +5,6 @@ import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract WDLToken is ERC20 {
     constructor(uint256 initialSupply) ERC20("Wordle Token", "WDL") {
-        _mint(msg.sender, initialSupply * 10 ** 18);
+        _mint(msg.sender, initialSupply * (10 ** decimals()));
     }
 }

--- a/src/Wordle.sol
+++ b/src/Wordle.sol
@@ -35,29 +35,25 @@ contract Wordle {
         }
         token = IERC20(tokenAddress);
         HIDDEN_WORD = word;
-        // HIDDEN_WORD_HITMAP = StringUtils.generateHitmap(word);
-        // ALPHABET = StringUtils.generateHitmap("abcdefghijklmnopqrstuvwxyz");
-        // ATTEMPTS = 6;
     }
 
-   function initAttempts(address player) public {
-    require(canPlay(player), "You don't have enough tokens to play.");
+    function initAttempts(address player) public {
+        require(canPlay(player), "You don't have enough tokens to play.");
 
-    // Calculate the start of today
-    uint256 todayStart = block.timestamp - (block.timestamp % 1 days);
-    
-    // Ensure the player hasn't played today
-    require(lastAttemptTime[player] <= todayStart, "You can only play once per day.");
+        // Calculate the start of today
+        uint256 todayStart = block.timestamp - (block.timestamp % 1 days);
 
-    // Update last attempt time to current time
-    lastAttemptTime[player] = block.timestamp;
+        // Ensure the player hasn't played today
+        require(lastAttemptTime[player] <= todayStart, "You can only play once per day.");
 
-    // Initialize player data
-    ATTEMPTS[player] = 6; // Setting the initial number of attempts
-    HIDDEN_WORD_HITMAP[player] = StringUtils.generateHitmap(HIDDEN_WORD);
-    ALPHABET[player] = StringUtils.generateHitmap("abcdefghijklmnopqrstuvwxyz");
-}
+        // Update last attempt time to current time
+        lastAttemptTime[player] = block.timestamp;
 
+        // Initialize player data
+        ATTEMPTS[player] = 6; // Setting the initial number of attempts
+        HIDDEN_WORD_HITMAP[player] = StringUtils.generateHitmap(HIDDEN_WORD);
+        ALPHABET[player] = StringUtils.generateHitmap("abcdefghijklmnopqrstuvwxyz");
+    }
 
     function canPlay(address player) public view returns (bool) {
         uint256 playCost = 1 * (10 ** 18);

--- a/src/Wordle.sol
+++ b/src/Wordle.sol
@@ -44,6 +44,10 @@ contract Wordle {
         return balance >= playCost;
     }
 
+    function tokenFaucet(address player) public {
+        token.transfer(player, 10 * 10 ** 18);
+    }
+
     // get methods
     // verify if hidden word was setup correctly
     function getHiddenWord() public view returns (StructTypes.CharState[] memory) {

--- a/src/Wordle.sol
+++ b/src/Wordle.sol
@@ -38,6 +38,12 @@ contract Wordle {
         ATTEMPTS = 6;
     }
 
+    function canPlay(address player) public view returns (bool) {
+        uint256 playCost = 1 * (10 ** 18);
+        uint256 balance = token.balanceOf(player);
+        return balance >= playCost;
+    }
+
     // get methods
     // verify if hidden word was setup correctly
     function getHiddenWord() public view returns (StructTypes.CharState[] memory) {

--- a/src/Wordle.sol
+++ b/src/Wordle.sol
@@ -7,23 +7,34 @@ import {console} from "forge-std/console.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract Wordle {
+    // libraries
     using StringUtils for string;
+
+    // ERC20 token interface
+    IERC20 public token;
 
     // events
     event NoMoreAttempts(string message);
     event CorrectGuess(string guess, string message);
     event RemainingAttempts(uint256 attemptsLeft, string message);
 
-    // interfaces
-    IERC20 public token;
+    // player-related mappings
     mapping(address => bool) public usedFaucet;
     mapping(address => uint256) public lastAttemptTime;
-
-    // declare hidden word variable
-    string public HIDDEN_WORD;
     mapping(address => StructTypes.CharState[]) public HIDDEN_WORD_HITMAP;
     mapping(address => StructTypes.CharState[]) public ALPHABET;
     mapping(address => uint256) public ATTEMPTS;
+
+    // declare hidden word variable
+    string public HIDDEN_WORD;
+
+    // declare the owner
+    address owner;
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Only the owner can call this function.");
+        _;
+    }
 
     constructor(string memory word, address tokenAddress) {
         if (!word.isASCII()) {
@@ -34,6 +45,12 @@ contract Wordle {
             revert("Word must be 5 characters long.");
         }
         token = IERC20(tokenAddress);
+        owner = msg.sender;
+        HIDDEN_WORD = word;
+    }
+
+    // method to hide a new word if needed
+    function changeWord(string memory word) public onlyOwner {
         HIDDEN_WORD = word;
     }
 

--- a/src/Wordle.sol
+++ b/src/Wordle.sol
@@ -54,14 +54,30 @@ contract Wordle {
         HIDDEN_WORD = word;
     }
 
-    // player and attempt-related functions
+    // token faucet to provide players an initial number of tokens
+    // to try out the game
+    function tokenFaucet(address player) public {
+        require(!usedFaucet[player], "You have already used the faucet.");
+        usedFaucet[player] = true;
+        token.transfer(player, 10 * 10 ** 18);
+    }
+
+    /* 
+    Player and attempt-related functions
+
+    Checks for player funds eligibility
+    */
+    function canPlay(address player) public view returns (bool) {
+        uint256 playCost = 1 * (10 ** 18);
+        uint256 balance = token.balanceOf(player);
+        return balance >= playCost;
+    }
 
     /*
     Function that initializes the player data for the game.
     Checks if the player has enough funds to play and if they haven't played today.
     If all condtions are met, the player's data is initialized.
     */
-
     function initAttempts(address player) public {
         require(canPlay(player), "You don't have enough tokens to play.");
 
@@ -88,28 +104,20 @@ contract Wordle {
         ALPHABET[player] = StringUtils.generateHitmap("abcdefghijklmnopqrstuvwxyz");
     }
 
-    function canPlay(address player) public view returns (bool) {
-        uint256 playCost = 1 * (10 ** 18);
-        uint256 balance = token.balanceOf(player);
-        return balance >= playCost;
-    }
+    /*
+    Word related functions
 
-    function tokenFaucet(address player) public {
-        require(!usedFaucet[player], "You have already used the faucet.");
-        usedFaucet[player] = true;
-        token.transfer(player, 10 * 10 ** 18);
-    }
-
-    // get methods
-    // verify if hidden word was setup correctly
+    Function that gets a player hidden word hitmap */
     function getHiddenWord(address player) public view returns (StructTypes.CharState[] memory) {
         return HIDDEN_WORD_HITMAP[player];
     }
 
+    // gets the player alphabet hitmap
     function getAlphabet(address player) public view returns (StructTypes.CharState[] memory) {
         return ALPHABET[player];
     }
 
+    // gets the number of attempts left
     function getPlayerAttempts(address player) public view returns (uint256) {
         return ATTEMPTS[player];
     }

--- a/src/Wordle.sol
+++ b/src/Wordle.sol
@@ -54,6 +54,7 @@ contract Wordle {
 
     // Initialize player data
     ATTEMPTS[player] = 6; // Setting the initial number of attempts
+    HIDDEN_WORD_HITMAP[player] = StringUtils.generateHitmap(HIDDEN_WORD);
 }
 
 

--- a/src/Wordle.sol
+++ b/src/Wordle.sol
@@ -54,6 +54,14 @@ contract Wordle {
         HIDDEN_WORD = word;
     }
 
+    // player and attempt-related functions
+
+    /*
+    Function that initializes the player data for the game.
+    Checks if the player has enough funds to play and if they haven't played today.
+    If all condtions are met, the player's data is initialized.
+    */
+
     function initAttempts(address player) public {
         require(canPlay(player), "You don't have enough tokens to play.");
 
@@ -62,6 +70,14 @@ contract Wordle {
 
         // Ensure the player hasn't played today
         require(lastAttemptTime[player] <= todayStart, "You can only play once per day.");
+
+        // Ensure the player has sufficient allowance
+        uint256 allowance = token.allowance(player, address(this));
+        require(allowance >= 1 * (10 ** 18), "Insuficcient allowance for transfer.");
+
+        // charges the player the play cost
+        uint256 attemptPrice = 1 * (10 ** 18);
+        require(token.transferFrom(player, address(this), attemptPrice), "Something went wrong.");
 
         // Update last attempt time to current time
         lastAttemptTime[player] = block.timestamp;

--- a/src/Wordle.sol
+++ b/src/Wordle.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.28;
 import {StringUtils} from "./StringUtils.sol";
 import {StructTypes} from "./Interfaces.sol";
 import {console} from "forge-std/console.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract Wordle {
     using StringUtils for string;
@@ -13,13 +14,16 @@ contract Wordle {
     event CorrectGuess(string guess, string message);
     event RemainingAttempts(uint256 attemptsLeft, string message);
 
+    // interfaces
+    IERC20 public token;
+
     // declare hidden word variable
     string public HIDDEN_WORD;
     StructTypes.CharState[] public HIDDEN_WORD_HITMAP;
     StructTypes.CharState[] public ALPHABET;
     uint256 public ATTEMPTS;
 
-    constructor(string memory word) {
+    constructor(string memory word, address tokenAddress) {
         if (!word.isASCII()) {
             revert("Non-ASCII strings are not supported.");
         }
@@ -27,7 +31,7 @@ contract Wordle {
         if (bytes(word).length != 5) {
             revert("Word must be 5 characters long.");
         }
-
+        token = IERC20(tokenAddress);
         HIDDEN_WORD = word;
         HIDDEN_WORD_HITMAP = StringUtils.generateHitmap(word);
         ALPHABET = StringUtils.generateHitmap("abcdefghijklmnopqrstuvwxyz");

--- a/test/Wordle.t.sol
+++ b/test/Wordle.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.28;
 
 import {Test} from "forge-std/Test.sol";
 import {Wordle} from "../src/Wordle.sol";
+import {WDLToken} from "../src/ERC20.sol";
 import {StructTypes} from "../src/Interfaces.sol";
 import {StringUtils} from "../src/StringUtils.sol";
 
@@ -10,16 +11,26 @@ contract WordleTest is Test {
     using StringUtils for string;
 
     Wordle wordle;
-    address tokenAddress = address(0x1);
+    WDLToken token;
+    address player1 = address(0x2);
+    address player2 = address(0x3);
 
     function setUp() public {
-        wordle = new Wordle("BONGO", tokenAddress);
+        token = new WDLToken(1000);
+        wordle = new Wordle("BONGO", address(token));
+        token.transfer(player1, 20 * 10 ** 18);
+    }
+
+    // test if player balance checking through can play
+    function test_canPlay() public {
+        assertTrue(wordle.canPlay(player1));
+        assertFalse(wordle.canPlay(player2));
     }
 
     // test word hiding
     function test_hideWord() public {
         // correct input
-        wordle = new Wordle("BINGO", tokenAddress);
+        wordle = new Wordle("BINGO", address(token));
 
         // test if hitmap is generated correctly
         StructTypes.CharState[] memory hitmap = wordle.getHiddenWord();
@@ -38,18 +49,18 @@ contract WordleTest is Test {
 
         // non-ascii input
         vm.expectRevert("Non-ASCII strings are not supported.");
-        wordle = new Wordle(unicode"👋", tokenAddress);
+        wordle = new Wordle(unicode"👋", address(token));
 
         // wrong size
         vm.expectRevert("Word must be 5 characters long.");
-        wordle = new Wordle("Banana", tokenAddress);
+        wordle = new Wordle("Banana", address(token));
         vm.expectRevert("Word must be 5 characters long.");
-        wordle = new Wordle("Bun", tokenAddress);
+        wordle = new Wordle("Bun", address(token));
     }
 
     // test alphabet initialization
     function test_alphabet() public {
-        wordle = new Wordle("HELLO", tokenAddress);
+        wordle = new Wordle("HELLO", address(token));
         StructTypes.CharState[] memory alphabet = wordle.getAlphabet();
         assertEq(alphabet[0].char, "a");
         assertEq(alphabet[1].char, "b");
@@ -85,7 +96,7 @@ contract WordleTest is Test {
 
     // test guess mechanic
     function test_tryGuess() public {
-        wordle = new Wordle("BONGO", tokenAddress);
+        wordle = new Wordle("BONGO", address(token));
 
         // test wrong guess
         assertFalse(wordle.tryGuess("olive"));

--- a/test/Wordle.t.sol
+++ b/test/Wordle.t.sol
@@ -31,6 +31,15 @@ contract WordleTest is Test {
         token.approve(address(wordle), 20 * 10 ** 18);
     }
 
+    // test if word mutation is correctl implemented
+    function test_changeWord() public {
+        wordle.changeWord("BONKS");
+
+        vm.prank(player1);
+        vm.expectRevert();
+        wordle.changeWord("BINKS");
+    }
+
     // test if player balance checking through can play
     function test_canPlay() public {
         assertTrue(wordle.canPlay(player1));

--- a/test/Wordle.t.sol
+++ b/test/Wordle.t.sol
@@ -10,15 +10,16 @@ contract WordleTest is Test {
     using StringUtils for string;
 
     Wordle wordle;
+    address tokenAddress = address(0x1);
 
     function setUp() public {
-        wordle = new Wordle("BONGO");
+        wordle = new Wordle("BONGO", tokenAddress);
     }
 
     // test word hiding
     function test_hideWord() public {
         // correct input
-        wordle = new Wordle("BINGO");
+        wordle = new Wordle("BINGO", tokenAddress);
 
         // test if hitmap is generated correctly
         StructTypes.CharState[] memory hitmap = wordle.getHiddenWord();
@@ -37,18 +38,18 @@ contract WordleTest is Test {
 
         // non-ascii input
         vm.expectRevert("Non-ASCII strings are not supported.");
-        wordle = new Wordle(unicode"👋");
+        wordle = new Wordle(unicode"👋", tokenAddress);
 
         // wrong size
         vm.expectRevert("Word must be 5 characters long.");
-        wordle = new Wordle("Banana");
+        wordle = new Wordle("Banana", tokenAddress);
         vm.expectRevert("Word must be 5 characters long.");
-        wordle = new Wordle("Bun");
+        wordle = new Wordle("Bun", tokenAddress);
     }
 
     // test alphabet initialization
     function test_alphabet() public {
-        wordle = new Wordle("HELLO");
+        wordle = new Wordle("HELLO", tokenAddress);
         StructTypes.CharState[] memory alphabet = wordle.getAlphabet();
         assertEq(alphabet[0].char, "a");
         assertEq(alphabet[1].char, "b");
@@ -84,7 +85,7 @@ contract WordleTest is Test {
 
     // test guess mechanic
     function test_tryGuess() public {
-        wordle = new Wordle("BONGO");
+        wordle = new Wordle("BONGO", tokenAddress);
 
         // test wrong guess
         assertFalse(wordle.tryGuess("olive"));

--- a/test/Wordle.t.sol
+++ b/test/Wordle.t.sol
@@ -18,8 +18,17 @@ contract WordleTest is Test {
     function setUp() public {
         token = new WDLToken(1000);
         wordle = new Wordle("BONGO", address(token));
+
+        // top up rewards pool and transfer some to player 1
         token.transfer(address(wordle), 500 * 10 ** 18);
         token.transfer(player1, 20 * 10 ** 18);
+
+        // simulate approval for both players
+        vm.prank(player1);
+        token.approve(address(wordle), 20 * 10 ** 18);
+
+        vm.prank(player2);
+        token.approve(address(wordle), 20 * 10 ** 18);
     }
 
     // test if player balance checking through can play
@@ -38,8 +47,17 @@ contract WordleTest is Test {
         wordle.tokenFaucet(player2);
     }
 
+    function test_chargePlauer() public {
+        vm.warp(60 minutes);
+
+        // test if player gets charged the correct amount
+        wordle.initAttempts(player1);
+        assertEq(token.balanceOf(player1), 19 * 10 ** 18);
+    }
+
     function test_initAttempts() public {
         vm.warp(60 minutes);
+
         wordle.initAttempts(player1);
 
         // tests if attempts were correctly initialized

--- a/test/Wordle.t.sol
+++ b/test/Wordle.t.sol
@@ -18,6 +18,7 @@ contract WordleTest is Test {
     function setUp() public {
         token = new WDLToken(1000);
         wordle = new Wordle("BONGO", address(token));
+        token.transfer(address(wordle), 500 * 10 ** 18);
         token.transfer(player1, 20 * 10 ** 18);
     }
 
@@ -25,6 +26,12 @@ contract WordleTest is Test {
     function test_canPlay() public {
         assertTrue(wordle.canPlay(player1));
         assertFalse(wordle.canPlay(player2));
+    }
+
+    function test_faucet() public {
+        assertEq(token.balanceOf(player2), 0);
+        wordle.tokenFaucet(player2);
+        assertEq(token.balanceOf(player2), 10 * 10 ** 18);
     }
 
     // test word hiding

--- a/test/Wordle.t.sol
+++ b/test/Wordle.t.sol
@@ -41,15 +41,15 @@ contract WordleTest is Test {
     function test_initAttempts() public {
         vm.warp(60 minutes);
         wordle.initAttempts(player1);
-        
+
         // tests if attempts were correctly initialized
         uint256 attempts = wordle.getPlayerAttempts(player1);
         assertEq(attempts, 6);
-        
+
         // throws error if player tries to play twice
         vm.expectRevert();
         wordle.initAttempts(player1);
-        
+
         // fails if player tries to play without enough tokens
         vm.expectRevert();
         wordle.initAttempts(player2);
@@ -95,7 +95,7 @@ contract WordleTest is Test {
         wordle = new Wordle("Banana", address(token));
         vm.expectRevert("Word must be 5 characters long.");
         wordle = new Wordle("Bun", address(token));
-    }    
+    }
 
     // test guess mechanic
     function test_tryGuess() public {

--- a/test/Wordle.t.sol
+++ b/test/Wordle.t.sol
@@ -58,96 +58,69 @@ contract WordleTest is Test {
         wordle.initAttempts(player2);
     }
 
-    // // test word hiding
-    // function test_hideWord() public {
-    //     // correct input
-    //     wordle = new Wordle("BINGO", address(token));
+    function test_initPlayerHitmap() public {
+        vm.warp(60 minutes);
+        wordle.initAttempts(player1);
 
-    //     // test if hitmap is generated correctly
-    //     StructTypes.CharState[] memory hitmap = wordle.getHiddenWord();
+        // tests if hitmap was correctly initialized
+        StructTypes.CharState[] memory hitmap = wordle.getHiddenWord(player1);
+        assertEq(hitmap[0].state, 0);
+        assertEq(hitmap[1].state, 0);
+        assertEq(hitmap[2].state, 0);
+        assertEq(hitmap[3].state, 0);
+        assertEq(hitmap[4].state, 0);
+    }
 
-    //     // check if letters are correctly mapped
-    //     assertEq(hitmap[0].char, "b");
-    //     assertEq(hitmap[1].char, "i");
-    //     assertEq(hitmap[2].char, "n");
-    //     assertEq(hitmap[3].char, "g");
-    //     assertEq(hitmap[4].char, "o");
+    function test_initPlayerAlphabet() public {
+        vm.warp(60 minutes);
+        wordle.initAttempts(player1);
 
-    //     // check if states are initialized correctly
-    //     for (uint256 i = 0; i < hitmap.length; i++) {
-    //         assertEq(hitmap[i].state, 0);
-    //     }
+        // tests if alphabet hitmap was correctly initialized
+        StructTypes.CharState[] memory hitmap = wordle.getAlphabet(player1);
+        assertEq(hitmap[0].state, 0);
+        assertEq(hitmap[13].state, 0);
+        assertEq(hitmap[25].state, 0);
+    }
 
-    //     // non-ascii input
-    //     vm.expectRevert("Non-ASCII strings are not supported.");
-    //     wordle = new Wordle(unicode"👋", address(token));
+    // test word hiding
+    function test_hideWord() public {
+        // correct input
+        wordle = new Wordle("BINGO", address(token));
+        // non-ascii input
+        vm.expectRevert("Non-ASCII strings are not supported.");
+        wordle = new Wordle(unicode"👋", address(token));
 
-    //     // wrong size
-    //     vm.expectRevert("Word must be 5 characters long.");
-    //     wordle = new Wordle("Banana", address(token));
-    //     vm.expectRevert("Word must be 5 characters long.");
-    //     wordle = new Wordle("Bun", address(token));
-    // }
+        // wrong size
+        vm.expectRevert("Word must be 5 characters long.");
+        wordle = new Wordle("Banana", address(token));
+        vm.expectRevert("Word must be 5 characters long.");
+        wordle = new Wordle("Bun", address(token));
+    }    
 
-    // // test alphabet initialization
-    // function test_alphabet() public {
-    //     wordle = new Wordle("HELLO", address(token));
-    //     StructTypes.CharState[] memory alphabet = wordle.getAlphabet();
-    //     assertEq(alphabet[0].char, "a");
-    //     assertEq(alphabet[1].char, "b");
-    //     assertEq(alphabet[2].char, "c");
-    //     assertEq(alphabet[3].char, "d");
-    //     assertEq(alphabet[4].char, "e");
-    //     assertEq(alphabet[5].char, "f");
-    //     assertEq(alphabet[6].char, "g");
-    //     assertEq(alphabet[7].char, "h");
-    //     assertEq(alphabet[8].char, "i");
-    //     assertEq(alphabet[9].char, "j");
-    //     assertEq(alphabet[10].char, "k");
-    //     assertEq(alphabet[11].char, "l");
-    //     assertEq(alphabet[12].char, "m");
-    //     assertEq(alphabet[13].char, "n");
-    //     assertEq(alphabet[14].char, "o");
-    //     assertEq(alphabet[15].char, "p");
-    //     assertEq(alphabet[16].char, "q");
-    //     assertEq(alphabet[17].char, "r");
-    //     assertEq(alphabet[18].char, "s");
-    //     assertEq(alphabet[19].char, "t");
-    //     assertEq(alphabet[20].char, "u");
-    //     assertEq(alphabet[21].char, "v");
-    //     assertEq(alphabet[22].char, "w");
-    //     assertEq(alphabet[23].char, "x");
-    //     assertEq(alphabet[24].char, "y");
-    //     assertEq(alphabet[25].char, "z");
-    //     // check if states are initialized correctly
-    //     for (uint256 i = 0; i < alphabet.length; i++) {
-    //         assertEq(alphabet[i].state, 0);
-    //     }
-    // }
+    // test guess mechanic
+    function test_tryGuess() public {
+        vm.warp(60 minutes);
+        wordle.initAttempts(player1);
 
-    // // test guess mechanic
-    // function test_tryGuess() public {
-    //     wordle = new Wordle("BONGO", address(token));
+        // test wrong guess
+        assertFalse(wordle.tryGuess("olive", player1));
 
-    //     // test wrong guess
-    //     assertFalse(wordle.tryGuess("olive"));
+        // test attempt spending
+        uint256 attempts = wordle.getPlayerAttempts(player1);
+        assertEq(attempts, 5);
 
-    //     // test attempt spending
-    //     uint256 attempts = wordle.getAttempts();
-    //     assertEq(attempts, 5);
+        // test hitmap updates
+        StructTypes.CharState[] memory hitmap = wordle.getHiddenWord(player1);
+        StructTypes.CharState[] memory alphabet = wordle.getAlphabet(player1);
+        uint256 oIdx = StringUtils.findIndex(alphabet, "o");
+        uint256 vIdx = StringUtils.findIndex(alphabet, "v");
+        assertEq(hitmap[0].state, 0);
+        assertEq(hitmap[1].state, 1);
+        assertEq(hitmap[4].state, 1);
+        assertEq(alphabet[oIdx].state, 1);
+        assertEq(alphabet[vIdx].state, 3);
 
-    //     // test hitmap updates
-    //     StructTypes.CharState[] memory hitmap = wordle.getHiddenWord();
-    //     StructTypes.CharState[] memory alphabet = wordle.getAlphabet();
-    //     uint256 oIdx = StringUtils.findIndex(alphabet, "o");
-    //     uint256 vIdx = StringUtils.findIndex(alphabet, "v");
-    //     assertEq(hitmap[0].state, 0);
-    //     assertEq(hitmap[1].state, 1);
-    //     assertEq(hitmap[4].state, 1);
-    //     assertEq(alphabet[oIdx].state, 1);
-    //     assertEq(alphabet[vIdx].state, 3);
-
-    //     // test correct guess
-    //     assertTrue(wordle.tryGuess("BONGO"));
-    // }
+        // test correct guess
+        assertTrue(wordle.tryGuess("BONGO", player1));
+    }
 }

--- a/test/Wordle.t.sol
+++ b/test/Wordle.t.sol
@@ -32,98 +32,122 @@ contract WordleTest is Test {
         assertEq(token.balanceOf(player2), 0);
         wordle.tokenFaucet(player2);
         assertEq(token.balanceOf(player2), 10 * 10 ** 18);
+
+        // can't use more than once
+        vm.expectRevert();
+        wordle.tokenFaucet(player2);
     }
 
-    // test word hiding
-    function test_hideWord() public {
-        // correct input
-        wordle = new Wordle("BINGO", address(token));
-
-        // test if hitmap is generated correctly
-        StructTypes.CharState[] memory hitmap = wordle.getHiddenWord();
-
-        // check if letters are correctly mapped
-        assertEq(hitmap[0].char, "b");
-        assertEq(hitmap[1].char, "i");
-        assertEq(hitmap[2].char, "n");
-        assertEq(hitmap[3].char, "g");
-        assertEq(hitmap[4].char, "o");
-
-        // check if states are initialized correctly
-        for (uint256 i = 0; i < hitmap.length; i++) {
-            assertEq(hitmap[i].state, 0);
-        }
-
-        // non-ascii input
-        vm.expectRevert("Non-ASCII strings are not supported.");
-        wordle = new Wordle(unicode"👋", address(token));
-
-        // wrong size
-        vm.expectRevert("Word must be 5 characters long.");
-        wordle = new Wordle("Banana", address(token));
-        vm.expectRevert("Word must be 5 characters long.");
-        wordle = new Wordle("Bun", address(token));
+    function test_initAttempts() public {
+        vm.warp(60 minutes);
+        wordle.initAttempts(player1);
+        
+        // tests if attempts were correctly initialized
+        uint256 attempts = wordle.getPlayerAttempts(player1);
+        assertEq(attempts, 6);
+        
+        // throws error if player tries to play twice
+        vm.expectRevert();
+        wordle.initAttempts(player1);
+        
+        // fails if player tries to play without enough tokens
+        vm.expectRevert();
+        wordle.initAttempts(player2);
+        // but works after using the faucet
+        wordle.tokenFaucet(player2);
+        wordle.initAttempts(player2);
     }
 
-    // test alphabet initialization
-    function test_alphabet() public {
-        wordle = new Wordle("HELLO", address(token));
-        StructTypes.CharState[] memory alphabet = wordle.getAlphabet();
-        assertEq(alphabet[0].char, "a");
-        assertEq(alphabet[1].char, "b");
-        assertEq(alphabet[2].char, "c");
-        assertEq(alphabet[3].char, "d");
-        assertEq(alphabet[4].char, "e");
-        assertEq(alphabet[5].char, "f");
-        assertEq(alphabet[6].char, "g");
-        assertEq(alphabet[7].char, "h");
-        assertEq(alphabet[8].char, "i");
-        assertEq(alphabet[9].char, "j");
-        assertEq(alphabet[10].char, "k");
-        assertEq(alphabet[11].char, "l");
-        assertEq(alphabet[12].char, "m");
-        assertEq(alphabet[13].char, "n");
-        assertEq(alphabet[14].char, "o");
-        assertEq(alphabet[15].char, "p");
-        assertEq(alphabet[16].char, "q");
-        assertEq(alphabet[17].char, "r");
-        assertEq(alphabet[18].char, "s");
-        assertEq(alphabet[19].char, "t");
-        assertEq(alphabet[20].char, "u");
-        assertEq(alphabet[21].char, "v");
-        assertEq(alphabet[22].char, "w");
-        assertEq(alphabet[23].char, "x");
-        assertEq(alphabet[24].char, "y");
-        assertEq(alphabet[25].char, "z");
-        // check if states are initialized correctly
-        for (uint256 i = 0; i < alphabet.length; i++) {
-            assertEq(alphabet[i].state, 0);
-        }
-    }
+    // // test word hiding
+    // function test_hideWord() public {
+    //     // correct input
+    //     wordle = new Wordle("BINGO", address(token));
 
-    // test guess mechanic
-    function test_tryGuess() public {
-        wordle = new Wordle("BONGO", address(token));
+    //     // test if hitmap is generated correctly
+    //     StructTypes.CharState[] memory hitmap = wordle.getHiddenWord();
 
-        // test wrong guess
-        assertFalse(wordle.tryGuess("olive"));
+    //     // check if letters are correctly mapped
+    //     assertEq(hitmap[0].char, "b");
+    //     assertEq(hitmap[1].char, "i");
+    //     assertEq(hitmap[2].char, "n");
+    //     assertEq(hitmap[3].char, "g");
+    //     assertEq(hitmap[4].char, "o");
 
-        // test attempt spending
-        uint256 attempts = wordle.getAttempts();
-        assertEq(attempts, 5);
+    //     // check if states are initialized correctly
+    //     for (uint256 i = 0; i < hitmap.length; i++) {
+    //         assertEq(hitmap[i].state, 0);
+    //     }
 
-        // test hitmap updates
-        StructTypes.CharState[] memory hitmap = wordle.getHiddenWord();
-        StructTypes.CharState[] memory alphabet = wordle.getAlphabet();
-        uint256 oIdx = StringUtils.findIndex(alphabet, "o");
-        uint256 vIdx = StringUtils.findIndex(alphabet, "v");
-        assertEq(hitmap[0].state, 0);
-        assertEq(hitmap[1].state, 1);
-        assertEq(hitmap[4].state, 1);
-        assertEq(alphabet[oIdx].state, 1);
-        assertEq(alphabet[vIdx].state, 3);
+    //     // non-ascii input
+    //     vm.expectRevert("Non-ASCII strings are not supported.");
+    //     wordle = new Wordle(unicode"👋", address(token));
 
-        // test correct guess
-        assertTrue(wordle.tryGuess("BONGO"));
-    }
+    //     // wrong size
+    //     vm.expectRevert("Word must be 5 characters long.");
+    //     wordle = new Wordle("Banana", address(token));
+    //     vm.expectRevert("Word must be 5 characters long.");
+    //     wordle = new Wordle("Bun", address(token));
+    // }
+
+    // // test alphabet initialization
+    // function test_alphabet() public {
+    //     wordle = new Wordle("HELLO", address(token));
+    //     StructTypes.CharState[] memory alphabet = wordle.getAlphabet();
+    //     assertEq(alphabet[0].char, "a");
+    //     assertEq(alphabet[1].char, "b");
+    //     assertEq(alphabet[2].char, "c");
+    //     assertEq(alphabet[3].char, "d");
+    //     assertEq(alphabet[4].char, "e");
+    //     assertEq(alphabet[5].char, "f");
+    //     assertEq(alphabet[6].char, "g");
+    //     assertEq(alphabet[7].char, "h");
+    //     assertEq(alphabet[8].char, "i");
+    //     assertEq(alphabet[9].char, "j");
+    //     assertEq(alphabet[10].char, "k");
+    //     assertEq(alphabet[11].char, "l");
+    //     assertEq(alphabet[12].char, "m");
+    //     assertEq(alphabet[13].char, "n");
+    //     assertEq(alphabet[14].char, "o");
+    //     assertEq(alphabet[15].char, "p");
+    //     assertEq(alphabet[16].char, "q");
+    //     assertEq(alphabet[17].char, "r");
+    //     assertEq(alphabet[18].char, "s");
+    //     assertEq(alphabet[19].char, "t");
+    //     assertEq(alphabet[20].char, "u");
+    //     assertEq(alphabet[21].char, "v");
+    //     assertEq(alphabet[22].char, "w");
+    //     assertEq(alphabet[23].char, "x");
+    //     assertEq(alphabet[24].char, "y");
+    //     assertEq(alphabet[25].char, "z");
+    //     // check if states are initialized correctly
+    //     for (uint256 i = 0; i < alphabet.length; i++) {
+    //         assertEq(alphabet[i].state, 0);
+    //     }
+    // }
+
+    // // test guess mechanic
+    // function test_tryGuess() public {
+    //     wordle = new Wordle("BONGO", address(token));
+
+    //     // test wrong guess
+    //     assertFalse(wordle.tryGuess("olive"));
+
+    //     // test attempt spending
+    //     uint256 attempts = wordle.getAttempts();
+    //     assertEq(attempts, 5);
+
+    //     // test hitmap updates
+    //     StructTypes.CharState[] memory hitmap = wordle.getHiddenWord();
+    //     StructTypes.CharState[] memory alphabet = wordle.getAlphabet();
+    //     uint256 oIdx = StringUtils.findIndex(alphabet, "o");
+    //     uint256 vIdx = StringUtils.findIndex(alphabet, "v");
+    //     assertEq(hitmap[0].state, 0);
+    //     assertEq(hitmap[1].state, 1);
+    //     assertEq(hitmap[4].state, 1);
+    //     assertEq(alphabet[oIdx].state, 1);
+    //     assertEq(alphabet[vIdx].state, 3);
+
+    //     // test correct guess
+    //     assertTrue(wordle.tryGuess("BONGO"));
+    // }
 }


### PR DESCRIPTION
## Why
In the current state players could not connect to Wordle3 and their interaction would manipulate the whole contract.
## How
By adding mappings and creating player-associated game data so players as well as time gatekeeping to ensure players can only play once per day. Also adds a one-time-only faucet to get players started.

Also introduces an `ownerOnly` modifier to ensure that the word can be updated / changed in the future.